### PR TITLE
Add speed typing minigame

### DIFF
--- a/encounter.py
+++ b/encounter.py
@@ -50,3 +50,7 @@ class EncounterManager:
             else:
                 # Draw a red rectangle for other encounters
                 pygame.draw.rect(surface, (200, 0, 0), rect)
+
+    def remove_encounter(self, name):
+        """Remove the first encounter with the given name."""
+        self.encounters = [e for e in self.encounters if e[0] != name]

--- a/main.py
+++ b/main.py
@@ -3,6 +3,7 @@ import sys
 from player import Player
 from map import GameMap
 from encounter import EncounterManager
+import speed_typing
 
 # Init
 pygame.init()
@@ -93,8 +94,13 @@ while True:
             sprite = player.sprite_front
         screen.blit(sprite, (20, screen.get_height() - sprite.get_height() - 20))
 
-        if pygame.time.get_ticks() - encounter_start >= 5000:
-            game_state = "combat"
+        if current_enemy == "Slime":
+            if speed_typing.run(screen):
+                encounters.remove_encounter("Slime")
+                game_state = "overworld"
+        else:
+            if pygame.time.get_ticks() - encounter_start >= 5000:
+                game_state = "combat"
 
     elif game_state == "combat":
         screen.fill((0, 0, 0))

--- a/speed_typing.py
+++ b/speed_typing.py
@@ -1,0 +1,46 @@
+import pygame
+import sys
+
+TARGET_SENTENCE = "Type this sentence to defeat the slime!"
+
+
+def run(surface):
+    """Run a simple speed typing minigame.
+
+    The given ``surface`` will be used for drawing the game. The function
+    blocks until the user successfully types ``TARGET_SENTENCE`` and returns
+    ``True``. If the window is closed, ``False`` is returned.
+    """
+    font = pygame.font.Font(None, 32)
+    clock = pygame.time.Clock()
+    typed = ""
+    while True:
+        for event in pygame.event.get():
+            if event.type == pygame.QUIT:
+                pygame.quit()
+                return False
+            if event.type == pygame.KEYDOWN:
+                if event.key == pygame.K_BACKSPACE:
+                    typed = typed[:-1]
+                elif event.key == pygame.K_RETURN:
+                    # ignore return key
+                    pass
+                else:
+                    typed += event.unicode
+
+        surface.fill((0, 0, 0))
+        target_surf = font.render(TARGET_SENTENCE, True, (255, 255, 255))
+        typed_surf = font.render(typed, True, (0, 255, 0))
+        surface.blit(
+            target_surf,
+            (surface.get_width() // 2 - target_surf.get_width() // 2, surface.get_height() // 3),
+        )
+        surface.blit(
+            typed_surf,
+            (surface.get_width() // 2 - typed_surf.get_width() // 2, surface.get_height() // 2),
+        )
+        pygame.display.flip()
+
+        if typed == TARGET_SENTENCE:
+            return True
+        clock.tick(60)


### PR DESCRIPTION
## Summary
- introduce a simple `speed_typing` mini‑game
- implement encounter removal functionality
- hook slime encounter to the typing game and return to the overworld on success

## Testing
- `python3 -m py_compile *.py`


------
https://chatgpt.com/codex/tasks/task_e_6849c8422aa4832e857e9cff70d7b5ca